### PR TITLE
trivial: Renaming 'CookieGraph' to 'PieChart'

### DIFF
--- a/data/local/adwaita-dark.css
+++ b/data/local/adwaita-dark.css
@@ -75,15 +75,15 @@ rg-graph.big {
     background-image: repeating-linear-gradient(0deg, #3f3f3f, #3f3f3f 1px, transparent 1px, transparent 57px);
 }
 
-CookieGraph.used, ColorRectangle.used {
+PieChart.used, ColorRectangle.used {
     color: #4a90d9;
 }
 
-CookieGraph.others, ColorRectangle.others {
+PieChart.others, ColorRectangle.others {
     color: #4d5356;
 }
 
-CookieGraph.available, ColorRectangle.available {
+PieChart.available, ColorRectangle.available {
     color: #232729;
 }
 

--- a/data/local/adwaita.css
+++ b/data/local/adwaita.css
@@ -81,15 +81,15 @@ rg-graph.big {
     background-image: repeating-linear-gradient(0deg, #e6e6e6, #e6e6e6 1px, transparent 1px, transparent 57px);
 }
 
-CookieGraph.used, ColorRectangle.used {
+PieChart.used, ColorRectangle.used {
     color: #4a90d9;
 }
 
-CookieGraph.others, ColorRectangle.others {
+PieChart.others, ColorRectangle.others {
     color: #707070;
 }
 
-CookieGraph.available, ColorRectangle.available {
+PieChart.available, ColorRectangle.available {
     color: #fafafa;
 }
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,6 +1,5 @@
 src/application.vala
 src/color-rectangle.vala
-src/cookie-graph.vala
 src/cpu-graph-table.vala
 src/cpu-graph.vala
 src/cpu-monitor.vala
@@ -24,6 +23,7 @@ src/network-graph.vala
 src/network-monitor.vala
 src/network-sub-view.vala
 src/performance-view.vala
+src/pie-chart.vala
 src/power-view.vala
 src/process-dialog.vala
 src/process-list-box.vala
@@ -31,8 +31,8 @@ src/process-row.vala
 src/process.vala
 src/settings.vala
 src/storage-graph.vala
-src/storage-list-box.vala
 src/storage-list.vala
+src/storage-main-list-box.vala
 src/storage-row.vala
 src/storage-view.vala
 src/sub-process-list-box.vala

--- a/src/graph-block.vala
+++ b/src/graph-block.vala
@@ -4,7 +4,7 @@ namespace Usage
 {
     public class GraphBlock : Gtk.Grid
     {
-        CookieGraph graph;
+        PieChart graph;
         GraphBlockRow application_row;
         GraphBlockRow others_row;
         GraphBlockRow available_row;
@@ -26,7 +26,7 @@ namespace Usage
             label.set_use_markup(true);
             this.attach(label, 0, 0, 1, 1);
 
-            graph = new CookieGraph();
+            graph = new PieChart();
             graph.margin = 15;
             graph.height_request = 90;
             graph.width_request = 90;

--- a/src/pie-chart.vala
+++ b/src/pie-chart.vala
@@ -2,7 +2,7 @@ using Gtk;
 
 namespace Usage {
 
-    public class CookieGraph : Gtk.DrawingArea
+    public class PieChart : Gtk.DrawingArea
     {
         int used_percentages = 0;
         int other_percentages = 0;
@@ -12,10 +12,10 @@ namespace Usage {
 
         class construct
         {
-            set_css_name("CookieGraph");
+            set_css_name("PieChart");
         }
 
-        public CookieGraph()
+        public PieChart()
         {
             set_styles();
 

--- a/src/process-dialog.vala
+++ b/src/process-dialog.vala
@@ -55,7 +55,7 @@ namespace Usage
             headerbar = new ProcessDialogHeaderBar(stop_button, pid, this.title);
             set_titlebar(headerbar);
 
-            Timeout.add((GLib.Application.get_default() as Application).settings.list_update_cookie_graphs_UI, update);
+            Timeout.add((GLib.Application.get_default() as Application).settings.list_update_pie_charts_UI, update);
             update();
     	}
 

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -8,7 +8,7 @@ namespace Usage {
         public uint graph_max_samples { get; set; default = 20; }
         public uint graph_update_interval { get { return 1000; }}
         public uint list_update_interval_UI { get; set; default = 5000; }
-        public uint list_update_cookie_graphs_UI { get; set; default = 1000; }
+        public uint list_update_pie_charts_UI { get; set; default = 1000; }
         public uint data_update_interval { get; set; default = 1000; }
     }
 }


### PR DESCRIPTION
I think that Cookie Graph is not a good name to refer to the common Pie Charts.

The Pie Chart is a common and well known to denominate this kind of statistical circular graphics according to Wikipedia [1]

[1] https://en.wikipedia.org/wiki/Pie_chart